### PR TITLE
http.h: Move 'u_long nonblocking' to _WIN32 block

### DIFF
--- a/http.h
+++ b/http.h
@@ -316,8 +316,8 @@ HTTP_SOCKET http_internal_connect( char const* address, char const* port )
         }
 
     // set socket to nonblocking mode
-    u_long nonblocking = 1;
     #ifdef _WIN32
+        u_long nonblocking = 1;
         int res = ioctlsocket( sock, FIONBIO, &nonblocking );
     #else
         int flags = fcntl( sock, F_GETFL, 0 );


### PR DESCRIPTION
When compiling `http.h` under Ubuntu 24.10 with GCC 15.1 and `-std=c23`, compiler throws error on `u_long` type name of `nonblocking` variable. `u_long` is Microsoft Windows specific, and in this case is only used by `ioctlsocket()`. Moving it one line down, allows for error-less compilation in specified environment.

```
http.h: In function ‘http_internal_connect’:
http.h:321:5: error: unknown type name ‘u_long’; did you mean ‘long’?
  321 |     u_long nonblocking = 1;
      |     ^~~~~~
      |     long
http.h:321:12: warning: unused variable ‘nonblocking’ [-Wunused-variable]
  321 |     u_long nonblocking = 1;
      |            ^~~~~~~~~~~
```